### PR TITLE
Changes the base URL to make the scraper work again

### DIFF
--- a/ree/core/scraper.py
+++ b/ree/core/scraper.py
@@ -80,7 +80,7 @@ class Scraper(object):
         return self.__getjson(response.text)
 
     def _makeurl(self, zone, date, system="Canarias"):
-        base = "https://demanda.ree.es/WSvisionaMoviles{2}Rest/resources/demandaGeneracion{2}?curva={0}&fecha={1}"
+        base = "https://demanda.ree.es/WSvisionaMoviles{2}Rest/resources/demandaGeneracion{2}5M?curva={0}&fecha={1}"
         return base.format(zone, date, system)
 
     def __getjson(self, text):

--- a/tests/core/test_scraper.py
+++ b/tests/core/test_scraper.py
@@ -30,10 +30,10 @@ class TestScraper(TestCase):
         zone = "GCANARIA"
         date = "2017-07-13"
         result = self.scrapper._makeurl(zone, date)
-        expected = "https://demanda.ree.es/WSvisionaMovilesCanariasRest/resources/demandaGeneracionCanarias?curva=GCANARIA&fecha=2017-07-13"
+        expected = "https://demanda.ree.es/WSvisionaMovilesCanariasRest/resources/demandaGeneracionCanarias5M?curva=GCANARIA&fecha=2017-07-13"
         self.assertEqual(result, expected)
         result = self.scrapper._makeurl(zone, date, "Baleares")
-        expected = "https://demanda.ree.es/WSvisionaMovilesBalearesRest/resources/demandaGeneracionBaleares?curva=GCANARIA&fecha=2017-07-13"
+        expected = "https://demanda.ree.es/WSvisionaMovilesBalearesRest/resources/demandaGeneracionBaleares5M?curva=GCANARIA&fecha=2017-07-13"
         self.assertEqual(result, expected)
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

After creating #4 I looked further into the issue, and it seems like the source has added `5M` after the "curva" in the URL. I haven't look at all URLs used, but I checked the following two:
<img width="235" alt="Screenshot 2022-06-19 at 11 04 16" src="https://user-images.githubusercontent.com/3296643/174473802-b87b534d-0663-4ea3-bade-151ac963494d.png">
<img width="304" alt="Screenshot 2022-06-19 at 11 04 40" src="https://user-images.githubusercontent.com/3296643/174473810-f4fbe111-7abb-4b71-927e-b772b1db8007.png">

It works as expected after the change in this PR (nevermind the additional debugging output in the screenshot):

<img width="585" alt="Screenshot 2022-06-19 at 11 08 56" src="https://user-images.githubusercontent.com/3296643/174473838-433cf57e-6fb6-4ee3-82d8-09aa0f763e2e.png">

This fixes #4