### PR TITLE
Fix python version on workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10.0
+        python-version: '3.11'
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip


### PR DESCRIPTION
Change python version to 3.11 when execute CI workflow